### PR TITLE
Revert "Scoop update for tilt version v0.26.0"

### DIFF
--- a/tilt.json
+++ b/tilt.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.26.0",
+    "version": "0.25.3",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/tilt-dev/tilt/releases/download/v0.26.0/tilt.0.26.0.windows.x86_64.zip",
+            "url": "https://github.com/tilt-dev/tilt/releases/download/v0.25.3/tilt.0.25.3.windows.x86_64.zip",
             "bin": [
                 "tilt.exe"
             ],
-            "hash": "94d1b6ea4bef9699ec4692a414c07f51b0c87e4bb45578688657a164df60a40c"
+            "hash": "c48f4adc9d35d6bc7841b66be25806ac555afea79e48ee236d67ebb2690c27d2"
         }
     },
     "homepage": "https://tilt.dev/",


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/revert:

e784d7216c05ebf3e0a1e8415ffb514490de31b5 (2022-03-14 22:16:51 -0400)
Revert "Scoop update for tilt version v0.26.0"
This reverts commit cdf8e468bd083e475f03e018c7e417b8bb9b76cc.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics